### PR TITLE
Update lot selection colors and mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <title>Mediterranee Imobiliaria - Mapa de Lotes</title>
     <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
         body {
             margin: 0;
@@ -44,6 +45,11 @@
         }
         button:hover {
             background-color: #2980b9;
+        }
+        @media (max-width: 600px) {
+            body { flex-direction: column; }
+            #sidebar { width: 100%; height: auto; }
+            #map { width: 100%; height: 60vh; }
         }
     </style>
 </head>
@@ -159,7 +165,7 @@
         const selecionado = document.getElementById('loteSelect').value;
         for (const key in poligonos) poligonos[key].setOptions({ fillColor: '#0000FF', strokeColor: '#0000FF' });
         if (selecionado && poligonos[selecionado]) {
-            poligonos[selecionado].setOptions({ fillColor: '#FF0000', strokeColor: '#FF0000' });
+            poligonos[selecionado].setOptions({ fillColor: '#00FF00', strokeColor: '#00FF00' });
             const bounds = new google.maps.LatLngBounds();
             lotes[selecionado].area.forEach(coord => bounds.extend(coord));
             map.fitBounds(bounds);


### PR DESCRIPTION
## Summary
- revert lot colors to blue and show selected lot in green
- add viewport meta tag and responsive layout for narrow screens

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685bec431e68832da914b5bbc66abe2f