### PR TITLE
Add Google Apps Script endpoints with CORS headers

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -1,0 +1,15 @@
+function doGet(e) {
+  const output = ContentService.createTextOutput(JSON.stringify({message: 'GET not implemented'}));
+  output.setMimeType(ContentService.MimeType.JSON);
+  output.setHeader('Access-Control-Allow-Origin', '*');
+  output.setHeader('Access-Control-Allow-Methods', 'GET, POST');
+  return output;
+}
+
+function doPost(e) {
+  const output = ContentService.createTextOutput(JSON.stringify({message: 'POST not implemented'}));
+  output.setMimeType(ContentService.MimeType.JSON);
+  output.setHeader('Access-Control-Allow-Origin', '*');
+  output.setHeader('Access-Control-Allow-Methods', 'GET, POST');
+  return output;
+}


### PR DESCRIPTION
## Summary
- create `Code.gs` with `doGet` and `doPost`
- configure JSON output and CORS headers

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685ca476af40832db621f4f234527837