### PR TITLE
Atualiza chamadas fetch com tratamento de erro

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,6 +117,10 @@
                       console.error('Erro ao processar lote:', lote, e);
                   }
               });
+          })
+          .catch(err => {
+              console.error('Erro ao carregar lotes', err);
+              alert('Falha ao carregar lotes');
           });
 
         map.addListener("click", (e) => {
@@ -302,10 +306,16 @@
                 descricao: descricao,
                 coordenadas: JSON.stringify(area)
             })
+        })
+        .then(r => r.text())
+        .then(() => {
+            limparFormulario();
+            alert('Lote salvo com sucesso!');
+        })
+        .catch(err => {
+            console.error('Erro ao salvar lote', err);
+            alert('Falha ao salvar lote');
         });
-
-        limparFormulario();
-        alert("Lote salvo com sucesso!");
     }
 
     function excluirLote() {
@@ -326,6 +336,12 @@
                 action: 'delete',
                 id: selecionado
             })
+        })
+        .then(r => r.text())
+        .then(() => alert('Lote excluído com sucesso!'))
+        .catch(err => {
+            console.error('Erro ao excluir lote', err);
+            alert('Falha ao excluir lote');
         });
     }
 


### PR DESCRIPTION
## Resumo
- adiciona blocos `catch` na leitura de lotes
- adiciona tratamento de erro e alerta nas operações de salvar e excluir lotes

## Testes
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ca4ef0360832d94ea66c748b5ea0f